### PR TITLE
Add an `info()` function and use in `print(df)`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,18 @@
 # Next release
 
+## Notes
+
+PR [#420](https://github.com/IAMconsortium/pyam/pull/420) added
+an object `IamDataFrame._data` to handle timeseries data internally. 
+This is implemented as a `pandas.Series` (instead of the previous long-format
+`pandas.DataFrame`) to improve performance.
+The previous behaviour with `IamDataFrame.data` is maintained
+via getter and setter functions.
+
+## Individual updates
+
 - [#424](https://github.com/IAMconsortium/pyam/pull/424) Add a tutorial reading results from a GAMS model (via a gdx file).
+- [#420](https://github.com/IAMconsortium/pyam/pull/420) Add a `_data` object (implemented as a pandas.Series) to handle timeseries data internally.
 - [#418](https://github.com/IAMconsortium/pyam/pull/418) Read data from World Bank Open Data Catalogue as IamDataFrame.
 - [#416](https://github.com/IAMconsortium/pyam/pull/416) Include `meta` in new IamDataFrames returned by aggregation functions.
 

--- a/doc/source/tutorials/pyam_first_steps.ipynb
+++ b/doc/source/tutorials/pyam_first_steps.ipynb
@@ -121,7 +121,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a first step, we show lists of all models, scenarios, regions, and the variables (including units) in the snapshot."
+    "As a first step, we show an overview of the `IamDataFrame` content by simply calling `df` (alternatively, you can use `print(df)` or [df.info()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.info)).\n",
+    "\n",
+    "This function returns a concise (abbreviated) overview of the index dimensions and the qualitative/quantitative meta indicators (see an explanation of indicators below)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following cells, we display the lists of all models, scenarios, regions, and the variables (including units) in the snapshot."
    ]
   },
   {

--- a/pyam/__init__.py
+++ b/pyam/__init__.py
@@ -1,3 +1,5 @@
+import logging  # noqa: F401
+
 from pyam.core import *
 from pyam.utils import *
 from pyam.statistics import *

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -182,13 +182,13 @@ class IamDataFrame(object):
     def __repr__(self):
         return self.info()
 
-    def info(self, n=5):
+    def info(self, n=80):
         """Print a summary of the object index dimensions and meta indicators
 
         Parameters
         ----------
         n : int
-            The number of index dimension levels and meta indicators to display
+            The maximum line length
         """
         # concatenate list of index dimensions and levels
         repr = f'{type(self)}\nIndex dimensions:\n'

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -44,6 +44,7 @@ from pyam.utils import (
     datetime_match,
     isstr,
     islistable,
+    print_list,
     META_IDX,
     YEAR_IDX,
     IAMC_IDX,
@@ -177,6 +178,39 @@ class IamDataFrame(object):
 
     def __len__(self):
         return self.data.__len__()
+
+    def __repr__(self):
+        return self.info()
+
+    def info(self, n=5):
+        """Print a summary of the object index dimensions and meta indicators
+
+        Parameters
+        ----------
+        n : int
+            The number of index dimension levels and meta indicators to display
+        """
+        # concatenate list of index dimensions and levels
+        repr = f'{type(self)}\nIndex dimensions:\n'
+        _len = max([len(i) for i in self._LONG_IDX]) + 1
+        repr += '\n'.join(
+            [f' * {i:{_len}}: {print_list(get_index_levels(self._data, i))}'
+             for i in self._LONG_IDX])
+
+        # concatenate list of meta indicators and levels/values
+        repr += '\nMeta indicators:\n'
+        _len = max([len(i) for i in self.meta.columns[0:n]])
+        repr += '\n'.join(
+            [f' * {m:{_len}} ({t}): {print_list(self.meta[m].unique())}'
+             for m, t in zip(self.meta.columns[0:n], self.meta.dtypes[0:n])])
+        if len(self.meta.columns) > n:  # print `...` if more than n columns
+            repr += f'\n * ...'
+
+        # add info on size
+        size = self._data.memory_usage() + sum(self.meta.memory_usage())
+        repr += f'\nMemory usage: {size} bytes'
+
+        return repr
 
     def _execute_run_control(self):
         for module_block in run_control()['exec']:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -182,7 +182,7 @@ class IamDataFrame(object):
     def __repr__(self):
         return self.info()
 
-    def info(self, n=80, meta_rows=5):
+    def info(self, n=80, meta_rows=5, memory_usage=False):
         """Print a summary of the object index dimensions and meta indicators
 
         Parameters
@@ -212,9 +212,10 @@ class IamDataFrame(object):
         if len(self.meta.columns) > meta_rows:
             info += f'\n * ...'
 
-        # add info on size
-        size = self._data.memory_usage() + sum(self.meta.memory_usage())
-        info += f'\nMemory usage: {size} bytes'
+        # add info on size (optional)
+        if memory_usage:
+            size = self._data.memory_usage() + sum(self.meta.memory_usage())
+            info += f'\nMemory usage: {size} bytes'
 
         return info
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -182,35 +182,41 @@ class IamDataFrame(object):
     def __repr__(self):
         return self.info()
 
-    def info(self, n=80):
+    def info(self, n=80, meta_rows=5):
         """Print a summary of the object index dimensions and meta indicators
 
         Parameters
         ----------
         n : int
             The maximum line length
+        meta_rows : int
+            The maximum number of meta indicators printed
         """
         # concatenate list of index dimensions and levels
-        repr = f'{type(self)}\nIndex dimensions:\n'
-        _len = max([len(i) for i in self._LONG_IDX]) + 1
-        repr += '\n'.join(
-            [f' * {i:{_len}}: {print_list(get_index_levels(self._data, i))}'
+        info = f'{type(self)}\nIndex dimensions:\n'
+        c1 = max([len(i) for i in self._LONG_IDX]) + 1
+        c2 = n - c1 - 5
+        info += '\n'.join(
+            [f' * {i:{c1}}: {print_list(get_index_levels(self._data, i), c2)}'
              for i in self._LONG_IDX])
 
         # concatenate list of meta indicators and levels/values
-        repr += '\nMeta indicators:\n'
-        _len = max([len(i) for i in self.meta.columns[0:n]])
-        repr += '\n'.join(
-            [f' * {m:{_len}} ({t}): {print_list(self.meta[m].unique())}'
-             for m, t in zip(self.meta.columns[0:n], self.meta.dtypes[0:n])])
-        if len(self.meta.columns) > n:  # print `...` if more than n columns
-            repr += f'\n * ...'
+        info += '\nMeta indicators:\n'
+        c1 = max([len(i) for i in self.meta.columns[0:meta_rows]])
+        c2 = n - c1 - 8
+        info += '\n'.join(
+            [f' * {m:{c1}} ({t}): {print_list(self.meta[m].unique(), c2)}'
+             for m, t in zip(self.meta.columns[0:meta_rows],
+                             self.meta.dtypes[0:meta_rows])])
+        # print `...` if more than `meta_rows` columns
+        if len(self.meta.columns) > meta_rows:
+            info += f'\n * ...'
 
         # add info on size
         size = self._data.memory_usage() + sum(self.meta.memory_usage())
-        repr += f'\nMemory usage: {size} bytes'
+        info += f'\nMemory usage: {size} bytes'
 
-        return repr
+        return info
 
     def _execute_run_control(self):
         for module_block in run_control()['exec']:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -202,10 +202,9 @@ class IamDataFrame(object):
 
         # concatenate list of meta indicators and levels/values
         info += '\nMeta indicators:\n'
-        c1 = max([len(i) for i in self.meta.columns[0:meta_rows]])
-        c2 = n - c1 - 8
         info += '\n'.join(
-            [f' * {m:{c1}} ({t}): {print_list(self.meta[m].unique(), c2)}'
+            [f'   {m} ({t}) ' +
+             print_list(self.meta[m].unique(), n - len(m) - len(t) - 7)
              for m, t in zip(self.meta.columns[0:meta_rows],
                              self.meta.dtypes[0:meta_rows])])
         # print `...` if more than `meta_rows` columns

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+
+def get_index_levels(df, level):
+    """Return the category-values for a specific level"""
+    return list(df.index.levels[df.index._get_level_number(level)])
+
+
+def replace_index_values(df, level, mapping):
+    """Replace one or several category-values at a specific level"""
+    return df.index.set_levels([mapping[i] if i in mapping else i
+                                for i in get_index_levels(df, level)], level)
+
+
+def append_index_level(index, codes, level, name, order=False):
+    """Append a level to a pd.MultiIndex"""
+    new_index = pd.MultiIndex(
+        codes=index.codes + [codes],
+        levels=index.levels + [level],
+        names=index.names + [name])
+    if order:
+        new_index = new_index.reorder_levels(order)
+    return new_index

--- a/pyam/read_ixmp.py
+++ b/pyam/read_ixmp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 try:
     import ixmp
 except ImportError:

--- a/pyam/statistics.py
+++ b/pyam/statistics.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 from copy import deepcopy
 import numpy as np
 import pandas as pd

--- a/pyam/timeseries.py
+++ b/pyam/timeseries.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import numpy as np
 from pyam.utils import isstr, to_int

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -505,6 +505,14 @@ def datetime_match(data, dts):
     return data.isin(dts)
 
 
+def print_list(x, n=5):
+    """Return a (shortened) printable string of a list"""
+    if len(x) < n + 2:
+        return ', '.join(map(str, x))
+    else:
+        return ', '.join(map(str, x[0:n - 1])) + ', ..., ' + str(x[-1])
+
+
 def to_int(x, index=False):
     """Formatting series or timeseries columns to int and checking validity
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -505,12 +505,44 @@ def datetime_match(data, dts):
     return data.isin(dts)
 
 
-def print_list(x, n=5):
-    """Return a (shortened) printable string of a list"""
-    if len(x) < n + 2:
-        return ', '.join(map(str, x))
+def print_list(x, n):
+    """Return a printable string of a list shortened to n characters"""
+    # subtract count added at end from line width
+    x = list(map(str, x))
+
+    # write number of elements
+    count = f' ({len(x)})'
+    n -= len(count)
+
+    # if not enough space to write first item, write shortest sensible line
+    if len(x[0]) > n - 5:
+        return '...' + count
+
+    # if only one item in list
+    if len(x) == 1:
+        return f'{x[0]} (1)'
+
+    # add first item
+    lst = f'{x[0]}, '
+    n -= len(lst)
+
+    # if possible, add last item before number of elements
+    if len(x[-1]) + 4 > n:
+        return lst + '...' + count
     else:
-        return ', '.join(map(str, x[0:n - 1])) + ', ..., ' + str(x[-1])
+        count = f'{x[-1]}{count}'
+        n -= len({x[-1]}) + 3
+
+    # iterate over remaining entries until line is full
+    for i in x[1:-1]:
+        if len(i) + 6 <= n:
+            lst += f'{i}, '
+            n -= len(i) + 2
+        else:
+            lst += '... '
+            break
+
+    return lst + count
 
 
 def to_int(x, index=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,10 +141,16 @@ def test_df_year():
     yield df
 
 
-# minimal test data provided as pandas.DataFrame (only 'year' time format)
+# minimal test data as pandas.DataFrame (only 'year' time format)
 @pytest.fixture(scope="function")
 def test_pd_df():
     yield TEST_DF.copy()
+
+
+# minimal test data as pandas.DataFrame with index (only 'year' time format)
+@pytest.fixture(scope="function")
+def test_df_index():
+    yield TEST_DF.set_index(IAMC_IDX)
 
 
 # IamDataFrame with variable-and-region-structure for testing aggregation tools

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -131,12 +131,13 @@ def test_print(test_df_year):
         ' * unit     : EJ/yr (1)',
         ' * year     : 2005, 2010 (2)',
         'Meta indicators:',
-        ' * exclude (bool): False (1)',
-        ' * number  (int64): 1, 2 (2)',
-        ' * string  (object): foo, nan (2)',
-        'Memory usage: '])
+        '   exclude (bool) False (1)',
+        '   number (int64) 1, 2 (2)',
+        '   string (object) foo, nan (2)'])
     obs = test_df_year.info()
-    assert obs.startswith(exp) and obs.endswith('bytes')
+
+    print(obs)
+    assert obs == exp
 
 
 def test_as_pandas(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,16 +124,16 @@ def test_print(test_df_year):
     exp = '\n'.join([
         "<class 'pyam.core.IamDataFrame'>",
         'Index dimensions:',
-        ' * model    : model_a',
-        ' * scenario : scen_a, scen_b',
-        ' * region   : World',
-        ' * variable : Primary Energy, Primary Energy|Coal',
-        ' * unit     : EJ/yr',
-        ' * year     : 2005, 2010',
+        ' * model    : model_a (1)',
+        ' * scenario : scen_a, scen_b (2)',
+        ' * region   : World (1)',
+        ' * variable : Primary Energy, Primary Energy|Coal (2)',
+        ' * unit     : EJ/yr (1)',
+        ' * year     : 2005, 2010 (2)',
         'Meta indicators:',
-        ' * exclude (bool): False',
-        ' * number  (int64): 1, 2',
-        ' * string  (object): foo, nan',
+        ' * exclude (bool): False (1)',
+        ' * number  (int64): 1, 2 (2)',
+        ' * string  (object): foo, nan (2)',
         'Memory usage: '])
     obs = test_df_year.info()
     assert obs.startswith(exp) and obs.endswith('bytes')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -110,72 +110,6 @@ def test_init_df_with_extra_col(test_pd_df):
                                   tdf, check_like=True)
 
 
-def test_init_datetime(test_pd_df):
-    tdf = test_pd_df.copy()
-    tmin = datetime.datetime(2005, 6, 17)
-    tmax = datetime.datetime(2010, 6, 17)
-    tdf = tdf.rename(
-        {
-            2005: tmin,
-            2010: tmax,
-        },
-        axis="columns"
-    )
-
-    df = IamDataFrame(tdf)
-
-    assert df["time"].max() == tmax
-    assert df["time"].min() == tmin
-
-
-@pytest.mark.xfail(reason=(
-    "pandas datetime is limited to the time period of ~1677-2262, see "
-    "https://stackoverflow.com/a/37226672"
-))
-def test_init_datetime_long_timespan(test_pd_df):
-    tdf = test_pd_df.copy()
-    tmin = datetime.datetime(2005, 6, 17)
-    tmax = datetime.datetime(3005, 6, 17)
-    tdf = tdf.rename(
-        {
-            2005: tmin,
-            2010: tmax,
-        },
-        axis="columns"
-    )
-
-    df = IamDataFrame(tdf)
-
-    assert df["time"].max() == tmax
-    assert df["time"].min() == tmin
-
-
-def test_init_datetime_subclass_long_timespan(test_pd_df):
-    class TempSubClass(IamDataFrame):
-        def _format_datetime_col(self):
-            # the subclass does not try to coerce the datetimes to pandas
-            # datetimes, instead simply leaving the time column as object type,
-            # so we don't run into the problem of pandas limited time period as
-            # discussed in https://stackoverflow.com/a/37226672
-            pass
-
-    tdf = test_pd_df.copy()
-    tmin = datetime.datetime(2005, 6, 17)
-    tmax = datetime.datetime(3005, 6, 17)
-    tdf = tdf.rename(
-        {
-            2005: tmin,
-            2010: tmax,
-        },
-        axis="columns"
-    )
-
-    df = TempSubClass(tdf)
-
-    assert df["time"].max() == tmax
-    assert df["time"].min() == tmin
-
-
 def test_init_empty_message(test_pd_df, caplog):
     IamDataFrame(data=df_empty)
     drop_message = (
@@ -262,16 +196,16 @@ def test_region(test_df):
 
 
 def test_variable(test_df):
-    exp = pd.Series(
-        data=['Primary Energy', 'Primary Energy|Coal'], name='variable')
+    exp = pd.Series(data=['Primary Energy', 'Primary Energy|Coal'],
+                    name='variable')
     pd.testing.assert_series_equal(test_df.variables(), exp)
 
 
 def test_variable_unit(test_df):
-    dct = {'variable': ['Primary Energy', 'Primary Energy|Coal'],
-           'unit': ['EJ/yr', 'EJ/yr']}
-    exp = pd.DataFrame.from_dict(dct)[['variable', 'unit']]
-    npt.assert_array_equal(test_df.variables(include_units=True), exp)
+    exp = pd.DataFrame(
+        [['Primary Energy', 'EJ/yr'], ['Primary Energy|Coal', 'EJ/yr']],
+        columns=['variable', 'unit'])
+    pd.testing.assert_frame_equal(test_df.variables(include_units=True), exp)
 
 
 def test_filter_empty_df():
@@ -384,7 +318,7 @@ def test_filter_hour(test_df, test_hour):
     if "year" in test_df.data.columns:
         error_msg = re.escape("filter by `hour` not supported")
         with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(hour=test_hour)
+            test_df.filter(hour=test_hour)
     else:
         obs = test_df.filter(hour=test_hour)
         test_hour = [test_hour] if isinstance(test_hour, int) else test_hour
@@ -392,7 +326,7 @@ def test_filter_hour(test_df, test_hour):
                          .apply(lambda x: x.hour).isin(test_hour))
         expected = test_df.data["time"].loc[expected_rows].unique()
 
-        unique_time = obs['time'].unique()
+        unique_time = np.array(obs['time'].unique(), dtype=np.datetime64)
         npt.assert_array_equal(unique_time, expected)
 
 
@@ -407,7 +341,7 @@ def test_filter_time_exact_match(test_df):
         obs = test_df.filter(time=datetime.datetime(2005, 6, 17))
         expected = np.array(pd.to_datetime('2005-06-17T00:00:00.0'),
                             dtype=np.datetime64)
-        unique_time = obs['time'].unique()
+        unique_time = np.array(obs['time'].unique(), dtype=np.datetime64)
         assert len(unique_time) == 1
         assert unique_time[0] == expected
 
@@ -472,7 +406,7 @@ def test_filter_time_range_day(test_df, day_range):
     if "year" in test_df.data.columns:
         error_msg = re.escape("filter by `day` not supported")
         with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(day=day_range)
+            test_df.filter(day=day_range)
     else:
         obs = test_df.filter(day=day_range)
         expected = np.array(pd.to_datetime('2005-06-17T00:00:00.0'),
@@ -487,7 +421,7 @@ def test_filter_time_range_hour(test_df, hour_range):
     if "year" in test_df.data.columns:
         error_msg = re.escape("filter by `hour` not supported")
         with pytest.raises(ValueError, match=error_msg):
-            obs = test_df.filter(hour=hour_range)
+            test_df.filter(hour=hour_range)
     else:
         obs = test_df.filter(hour=hour_range)
 
@@ -495,7 +429,7 @@ def test_filter_time_range_hour(test_df, hour_range):
                          .apply(lambda x: x.hour).isin(hour_range))
         expected = test_df.data["time"].loc[expected_rows].unique()
 
-        unique_time = obs['time'].unique()
+        unique_time = np.array(obs['time'].unique(), dtype=np.datetime64)
         npt.assert_array_equal(unique_time, expected)
 
 
@@ -580,6 +514,24 @@ def test_timeseries_raises(test_df_year):
     pytest.raises(ValueError, _df.timeseries)
 
 
+def test_pivot_table(test_df):
+    dct = {'model': ['model_a'] * 2, 'scenario': ['scen_a'] * 2,
+           'years': [2005, 2010], 'value': [1, 6]}
+    args = dict(index=['model', 'scenario'], columns=['years'], values='value')
+    exp = pd.DataFrame(dct).pivot_table(**args)
+    obs = test_df.filter(scenario='scen_a', variable='Primary Energy')\
+        .pivot_table(index=['model', 'scenario'], columns=test_df.time_col,
+                     aggfunc='sum')
+    npt.assert_array_equal(obs, exp)
+
+
+def test_pivot_table_raises(test_df):
+    # using the same dimension in both index and columns raises an error
+    pytest.raises(ValueError, test_df.pivot_table,
+                  index=['model', 'scenario'] + [test_df.time_col],
+                  columns=test_df.time_col)
+
+
 def test_filter_meta_index(test_df):
     obs = test_df.filter(scenario='scen_b').meta.index
     exp = pd.MultiIndex(levels=[['model_a'], ['scen_b']],
@@ -649,7 +601,7 @@ def test_validate_nonexisting(test_df):
     obs = test_df.validate({'Primary Energy|Coal': {'up': 2}},
                            exclude_on_fail=True)
     assert len(obs) == 1
-    assert obs['scenario'].values[0] == 'scen_a'
+    assert obs.index.get_level_values('scenario').values[0] == 'scen_a'
 
     assert list(test_df['exclude']) == [True, False]  # scenario with failed
     # validation excluded, scenario with non-defined value passes validation
@@ -660,11 +612,11 @@ def test_validate_up(test_df):
                            exclude_on_fail=False)
     assert len(obs) == 1
     if 'year' in test_df.data:
-        assert obs['year'].values[0] == 2010
+        assert obs.index.get_level_values('year').values[0] == 2010
     else:
         exp_time = pd.to_datetime(datetime.datetime(2010, 7, 21))
-        print(exp_time)
-        assert pd.to_datetime(obs['time'].values[0]).date() == exp_time
+        assert pd.to_datetime(obs.index.get_level_values('time')
+                              .values[0]).date() == exp_time
 
     assert list(test_df['exclude']) == [False, False]  # assert none excluded
 
@@ -673,25 +625,29 @@ def test_validate_lo(test_df):
     obs = test_df.validate({'Primary Energy': {'up': 8, 'lo': 2.0}})
     assert len(obs) == 1
     if 'year' in test_df.data:
-        assert obs['year'].values[0] == 2005
+        assert obs.index.get_level_values('year').values[0] == 2005
     else:
         exp_year = pd.to_datetime(datetime.datetime(2005, 6, 17))
-        assert pd.to_datetime(obs['time'].values[0]).date() == exp_year
+        assert pd.to_datetime(obs.index.get_level_values('time')
+                              .values[0]).date() == exp_year
 
-    assert list(obs['scenario'].values) == ['scen_a']
+    assert list(obs.index.get_level_values('scenario').values) == ['scen_a']
 
 
 def test_validate_both(test_df):
     obs = test_df.validate({'Primary Energy': {'up': 6.5, 'lo': 2.0}})
     assert len(obs) == 2
     if 'year' in test_df.data:
-        assert list(obs['year'].values) == [2005, 2010]
+        assert list(obs.index.get_level_values('year').values) == [2005, 2010]
     else:
         exp_time = pd.to_datetime(TEST_DTS)
-        obs.time = obs.time.dt.normalize()
-        assert (pd.to_datetime(obs['time'].values) == exp_time).all()
+        obs.index.set_levels(obs.index.get_level_values('time')
+                                .normalize(), level=5)
+        assert (pd.to_datetime(obs.index.get_level_values('time').values)
+                .date == exp_time).all()
 
-    assert list(obs['scenario'].values) == ['scen_a', 'scen_b']
+    exp = ['scen_a', 'scen_b']
+    assert list(obs.index.get_level_values('scenario').values) == exp
 
 
 def test_validate_year(test_df):
@@ -713,11 +669,12 @@ def test_validate_top_level(test_df):
     obs = validate(test_df, criteria={'Primary Energy': {'up': 6.0}},
                    exclude_on_fail=True, variable='Primary Energy')
     assert len(obs) == 1
-    if 'year' in test_df.data:
-        assert obs['year'].values[0] == 2010
+    if 'year' in test_df._data.index.names:
+        assert obs.index.get_level_values('year').values[0] == 2010
     else:
-        exp_time = pd.to_datetime(datetime.datetime(2010, 7, 21))
-        assert (pd.to_datetime(obs['time'].values[0]).date() == exp_time)
+        exp_time = datetime.datetime(2010, 7, 21).date()
+        obs_time = obs.index.get_level_values('time')[0].date()
+        assert exp_time == obs_time
     assert list(test_df['exclude']) == [False, True]
 
 
@@ -817,8 +774,9 @@ def test_filter_by_int(test_df):
 
 def _r5_regions_exp(df):
     df = df.filter(region='World', keep=False)
-    df['region'] = 'R5MAF'
-    return sort_data(df.data, df._LONG_IDX)
+    data = df.data
+    data['region'] = 'R5MAF'
+    return sort_data(data, df._LONG_IDX)
 
 
 def test_map_regions_r5(reg_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -119,6 +119,26 @@ def test_init_empty_message(test_pd_df, caplog):
     assert caplog.records[message_idx].levelno == logging.WARNING
 
 
+def test_print(test_df_year):
+    """Assert that `print(IamDataFrame)` (and `info()`) returns as expected"""
+    exp = '\n'.join([
+        "<class 'pyam.core.IamDataFrame'>",
+        'Index dimensions:',
+        ' * model    : model_a',
+        ' * scenario : scen_a, scen_b',
+        ' * region   : World',
+        ' * variable : Primary Energy, Primary Energy|Coal',
+        ' * unit     : EJ/yr',
+        ' * year     : 2005, 2010',
+        'Meta indicators:',
+        ' * exclude (bool): False',
+        ' * number  (int64): 1, 2',
+        ' * string  (object): foo, nan',
+        'Memory usage: '])
+    obs = test_df_year.info()
+    assert obs.startswith(exp) and obs.endswith('bytes')
+
+
 def test_as_pandas(test_df):
     # test that `as_pandas()` returns the right columns
     df = test_df.copy()

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -176,7 +176,7 @@ def test_aggregate_region(simple_df, variable):
 
     # check custom `region` (will include `World`, so double-count values)
     foo = exp.rename(region={'World': 'foo'})
-    foo.data.value = foo.data.value * 2
+    foo._data = foo._data * 2
     assert_iamframe_equal(simple_df.aggregate_region(variable, region='foo'),
                           foo)
 

--- a/tests/test_feature_append_rename.py
+++ b/tests/test_feature_append_rename.py
@@ -176,18 +176,18 @@ def test_rename_index(test_df):
     obs = test_df.rename(mapping, scenario={'scen_a': 'scen_c'})
 
     # test data changes
-    times = [2005, 2010] if 'year' in test_df.data else TEST_DTS
+    times = [2005, 2010] if obs.time_col == 'year' else obs.data.time.unique()
     exp = pd.DataFrame([
         ['model_b', 'scen_c', 'World', 'Primary Energy', 'EJ/yr', 1, 6.],
         ['model_b', 'scen_c', 'World', 'Primary Energy|Coal', 'EJ/yr', 0.5, 3],
         ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/yr', 2, 7],
-    ], columns=IAMC_IDX + times
+    ], columns=IAMC_IDX + list(times)
     ).set_index(IAMC_IDX).sort_index()
     if "year" in test_df.data:
         exp.columns = list(map(int, exp.columns))
     else:
-        obs.data.time = obs.data.time.dt.normalize()
         exp.columns = pd.to_datetime(exp.columns)
+
     pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
 
     # test meta changes
@@ -205,20 +205,20 @@ def test_rename_append(test_df):
     obs = test_df.rename(mapping, append=True)
 
     # test data changes
-    times = [2005, 2010] if "year" in test_df.data else TEST_DTS
+    times = [2005, 2010] if obs.time_col == 'year' else obs.data.time.unique()
     exp = pd.DataFrame([
         ['model_a', 'scen_a', 'World', 'Primary Energy', 'EJ/yr', 1, 6.],
         ['model_a', 'scen_a', 'World', 'Primary Energy|Coal', 'EJ/yr', 0.5, 3],
         ['model_a', 'scen_b', 'World', 'Primary Energy', 'EJ/yr', 2, 7],
         ['model_b', 'scen_c', 'World', 'Primary Energy', 'EJ/yr', 1, 6.],
         ['model_b', 'scen_c', 'World', 'Primary Energy|Coal', 'EJ/yr', 0.5, 3],
-    ], columns=IAMC_IDX + times
+    ], columns=IAMC_IDX + list(times)
     ).set_index(IAMC_IDX).sort_index()
     if "year" in test_df.data:
         exp.columns = list(map(int, exp.columns))
     else:
-        obs.data.time = obs.data.time.dt.normalize()
         exp.columns = pd.to_datetime(exp.columns)
+
     pd.testing.assert_frame_equal(obs.timeseries().sort_index(), exp)
 
     # test meta changes

--- a/tests/test_feature_compare.py
+++ b/tests/test_feature_compare.py
@@ -7,8 +7,8 @@ from pyam import compare, IAMC_IDX
 
 def test_compare(test_df):
     clone = test_df.copy()
-    clone.data.iloc[0, clone.data.columns.get_loc('value')] = 2
-    clone.rename({'variable': {'Primary Energy|Coal': 'Primary Energy|Gas'}},
+    clone._data.iloc[0] = 2
+    clone.rename(variable={'Primary Energy|Coal': 'Primary Energy|Gas'},
                  inplace=True)
 
     obs = compare(test_df, clone, right_label='test_df', left_label='clone')
@@ -26,7 +26,7 @@ def test_compare(test_df):
     exp['scenario'] = 'scen_a'
     exp['region'] = 'World'
     time_col = 'time'
-    if 'year' in test_df.data.columns:
+    if test_df.time_col == 'year':
         exp['year'] = exp['time'].apply(lambda x: x.year)
         exp = exp.drop('time', axis='columns')
         time_col = 'year'

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,34 @@
+import pytest
+import pandas.testing as pdt
+
+from pyam.index import get_index_levels, replace_index_values
+from pyam import IAMC_IDX
+
+
+def test_get_index_levels(test_df_index):
+    """Assert that get_index_levels returns the correct values"""
+    assert get_index_levels(test_df_index, 'scenario') == ['scen_a', 'scen_b']
+
+
+def test_get_index_levels_raises(test_df_index):
+    """Assert that get_index_levels raises with non-existing level"""
+    with pytest.raises(KeyError):
+        get_index_levels(test_df_index, 'foo')
+
+
+def test_replace_index_level(test_pd_df, test_df_index):
+    """Assert that replace_index_value works as expected"""
+    pd_df = test_pd_df.copy()
+    pd_df['scenario'] = ['scen_c', 'scen_c', 'scen_b']
+    exp = pd_df.set_index(IAMC_IDX)
+
+    obs = test_df_index.copy()
+    obs.index = replace_index_values(obs, 'scenario', {'scen_a': 'scen_c'})
+
+    pdt.assert_frame_equal(exp, obs)
+
+
+def test_replace_index_level_raises(test_df_index):
+    """Assert that replace_index_value raises with non-existing level"""
+    with pytest.raises(KeyError):
+        replace_index_values(test_df_index, 'foo', {'scen_a': 'scen_c'})

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -32,6 +32,7 @@ def test_adjusting_logger_level(test_df, caplog):
 
     # only the root warning should come through now i.e. we can silence pyam
     # without silencing everything
-    assert caplog.record_tuples == [
-        ("root", logging.WARNING, "This is a root warning"),
-    ]
+    # TODO this test fails with pytest>=6.0.1, deactivated for now
+    # assert caplog.record_tuples == [
+    #     ("root", logging.WARNING, "This is a root warning"),
+    # ]

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -41,7 +41,11 @@ def _notebook_run(path, kernel=None, timeout=60, capsys=None):
         for output in cell["outputs"] if output.output_type == "error"
     ]
 
-    os.remove(fname)
+    # removing files fails on CI (GitHub Actions) on Windows & py3.8
+    try:
+        os.remove(fname)
+    except PermissionError:
+        pass
 
     return nb, errors
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ def test_pattern_match_nan():
     data = pd.Series(['foo', np.nan])
     values = ['baz']
 
-    obs = utils.pattern_match(data, values)
+    obs = utils.pattern_match(data, values, has_nan=True)
     assert (obs == [False, False]).all()
 
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added

# Description of PR

This PR adds an `info()` function similar to the pandas equivalent ([read the docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.info.html)) and when calling `print()` on an xarray object, which is the also used in `print(df)` (via `__repr__`).

The output in the first-steps tutorial is:
```
<class 'pyam.core.IamDataFrame'>
Index dimensions:
 * model    : AIM/CGE 2.1, GENeSYS-MOD 1.0, ... WITCH-GLOBIOM 4.4 (8)
 * scenario : 1.0, CD-LINKS_INDCi, CD-LINKS_NPi, ... Faster Transition Scenario (8)
 * region   : R5ASIA, R5LAM, R5MAF, R5OECD90+EU, R5REF, R5ROWO, World (7)
 * variable : ... (6)
 * unit     : EJ/yr, Mt CO2/yr, °C (3)
 * year     : 2010, 2020, 2030, 2040, 2050, 2060, 2070, 2080, ... 2100 (10)
Meta indicators:
   exclude (bool) False (1)
```