### PR TITLE
refactor 'timeseries()' and 'pivot_table'

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -349,6 +349,9 @@ class IamDataFrame(object):
         index = [index] if isstr(index) else index
         columns = [columns] if isstr(columns) else columns
 
+        if values != 'value':
+            raise ValueError("This method only supports `values='value'`!")
+
         df = self._data
 
         # allow 'aggfunc' to be passed as string for easier user interface

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -357,14 +357,14 @@ class IamDataFrame(object):
         # allow 'aggfunc' to be passed as string for easier user interface
         if isstr(aggfunc):
             if aggfunc == 'count':
-                df = self._data.groupby(index + columns, as_index=False).count()
+                df = self._data.groupby(index + columns).count()
                 fill_value = 0
             elif aggfunc == 'mean':
-                df = self._data.groupby(index + columns, as_index=False).mean()\
+                df = self._data.groupby(index + columns).mean()\
                     .round(2)
                 fill_value = 0 if style == 'heatmap' else ""
             elif aggfunc == 'sum':
-                df = self._data.groupby(index + columns, as_index=False).sum()
+                df = self._data.groupby(index + columns).sum()
                 fill_value = 0 if style == 'heatmap' else ""
 
         df = df.unstack(level=columns, fill_value=fill_value)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -349,24 +349,22 @@ class IamDataFrame(object):
         index = [index] if isstr(index) else index
         columns = [columns] if isstr(columns) else columns
 
-        df = self.data
+        df = self._data
 
         # allow 'aggfunc' to be passed as string for easier user interface
         if isstr(aggfunc):
             if aggfunc == 'count':
-                df = self.data.groupby(index + columns, as_index=False).count()
+                df = self._data.groupby(index + columns, as_index=False).count()
                 fill_value = 0
             elif aggfunc == 'mean':
-                df = self.data.groupby(index + columns, as_index=False).mean()\
+                df = self._data.groupby(index + columns, as_index=False).mean()\
                     .round(2)
-                aggfunc = np.sum
                 fill_value = 0 if style == 'heatmap' else ""
             elif aggfunc == 'sum':
-                aggfunc = np.sum
+                df = self._data.groupby(index + columns, as_index=False).sum()
                 fill_value = 0 if style == 'heatmap' else ""
 
-        df = df.pivot_table(values=values, index=index, columns=columns,
-                            aggfunc=aggfunc, fill_value=fill_value)
+        df = df.unstack(level=columns, fill_value=fill_value)
         return df
 
     def interpolate(self, time):
@@ -473,13 +471,8 @@ class IamDataFrame(object):
         if self.empty:
             raise ValueError('this `IamDataFrame` is empty')
 
-        index = IAMC_IDX if iamc_index else IAMC_IDX + self.extra_cols
-        df = (
-            self.data
-            .pivot_table(index=index, columns=self.time_col)
-            .value  # column name
-            .rename_axis(None, axis=1)
-        )
+        df = self._data.unstack(level=self.time_col).rename_axis(None, axis=1)
+
         if df.index.has_duplicates:
             raise ValueError('timeseries object has duplicates in index ',
                              'use `iamc_index=False`')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -521,6 +521,24 @@ def test_timeseries_raises(test_df_year):
     pytest.raises(ValueError, _df.timeseries)
 
 
+def test_pivot_table(test_df):
+    dct = {'model': ['model_a'] * 2, 'scenario': ['scen_a'] * 2,
+           'years': [2005, 2010], 'value': [1, 6]}
+    exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
+                                        columns=['years'], values='value')
+    obs = test_df.filter(scenario='scen_a',
+                        variable='Primary Energy').pivot_table(
+                            index=['model', 'scenario'], 
+                            columns=test_df.time_col, aggfunc='sum')
+    npt.assert_array_equal(obs, exp)
+
+
+def test_pivot_table_raises(test_df):
+    pytest.raises(ValueError, test_df.pivot_table, 
+                    index=['model', 'scenario']+[test_df.time_col], 
+                    columns=test_df.time_col)
+
+
 def test_filter_meta_index(test_df):
     obs = test_df.filter(scenario='scen_b').meta.index
     exp = pd.MultiIndex(levels=[['model_a'], ['scen_b']],


### PR DESCRIPTION
This PR refactors the `timeseries()` and `pivot_table()` functions to use `self._data`