### PR TITLE
Refactoring the `_apply_filters()` implementation

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1322,8 +1322,7 @@ class IamDataFrame(object):
                 matches = pattern_match(self.meta[col], values, regexp=regexp,
                                         has_nan=True)
                 cat_idx = self.meta[matches].index
-                keep_col = (self.data[META_IDX].set_index(META_IDX)
-                                .index.isin(cat_idx))
+                keep_col = _make_index(self._data, unique=False).isin(cat_idx)
 
             elif col == 'variable':
                 level = filters['level'] if 'level' in filters else None
@@ -1807,15 +1806,17 @@ def _apply_criteria(df, criteria, **kwargs):
     return df
 
 
-def _make_index(df, cols=META_IDX):
-    """Create an index from the columns of a dataframe or series"""
+def _make_index(df, cols=META_IDX, unique=True):
+    """Create an index from the columns/index of a dataframe or series"""
     def _get_col(c):
         try:
             return df.index.get_level_values(c)
         except KeyError:
             return df[c]
 
-    index = pd.unique(list(zip(*[_get_col(col) for col in cols])))
+    index = list(zip(*[_get_col(col) for col in cols]))
+    if unique:
+        index = pd.unique(index)
     return pd.MultiIndex.from_tuples(index, names=tuple(cols))
 
 

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1293,7 +1293,7 @@ class IamDataFrame(object):
         ret._data = ret._data[list(_keep)]
         ret._data.index = ret._data.index.remove_unused_levels()
 
-        idx = _make_index(ret.data)
+        idx = _make_index(ret._data)
         if len(idx) == 0:
             logger.warning('Filtered IamDataFrame is empty!')
         ret.meta = ret.meta.loc[idx]

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1329,10 +1329,7 @@ class IamDataFrame(object):
                 col_values = pd.Series(get_index_levels(self._data, col))
                 where = pattern_match(col_values, values, level, regexp)
 
-                keep_col = np.array([False] * len(self))
-                for v in col_values[where]:
-                    keep_val = self._data.index.get_loc_level(v, level=col)[0]
-                    keep_col = np.logical_or(keep_col, keep_val)
+                keep_col = self._get_keep_col(col_values[where], col)
 
             elif col == 'year':
                 _data = self.data[col] if self.time_col != 'time' \
@@ -1383,6 +1380,14 @@ class IamDataFrame(object):
             keep = np.logical_and(keep, keep_col)
 
         return keep
+
+    def _get_keep_col(self, values, col):
+        """Get the a list of booleans by filtering on values"""
+        keep_col = np.array([False] * len(self))
+        for v in values:
+            keep_col = np.logical_or(
+                keep_col, self._data.index.get_loc_level(v, level=col)[0])
+        return keep_col
 
     def col_apply(self, col, func, *args, **kwargs):
         """Apply a function to a column of data or meta

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1367,13 +1367,17 @@ class IamDataFrame(object):
 
             elif col == 'level':
                 if 'variable' not in filters.keys():
-                    keep_col = find_depth(self._data.index.get_level_values(3),
-                                          level=values)
+                    v = 'variable'
+                    col_values = pd.Series(get_index_levels(self._data, v))
+                    where = find_depth(col_values, level=values)
+                    keep_col = get_keep_col(self._data, col_values[where], v)
                 else:
                     continue
 
-            elif col in self.data.columns:
-                keep_col = pattern_match(self.data[col], values, regexp=regexp)
+            elif col in self._data.index.names:
+                col_values = pd.Series(get_index_levels(self._data, col))
+                where = pattern_match(col_values, values, regexp=regexp)
+                keep_col = get_keep_col(self._data, col_values[where], col)
 
             else:
                 _raise_filter_error(col)

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1326,8 +1326,13 @@ class IamDataFrame(object):
 
             elif col == 'variable':
                 level = filters['level'] if 'level' in filters else None
-                keep_col = pattern_match(self._data.index.get_level_values(3),
-                                         values, level, regexp)
+                col_values = pd.Series(get_index_levels(self._data, col))
+                where = pattern_match(col_values, values, level, regexp)
+
+                keep_col = np.array([False] * len(self))
+                for v in col_values[where]:
+                    keep_val = self._data.index.get_loc_level(v, level=col)[0]
+                    keep_col = np.logical_or(keep_col, keep_val)
 
             elif col == 'year':
                 _data = self.data[col] if self.time_col != 'time' \

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -34,6 +34,7 @@ from pyam.utils import (
     format_data,
     format_time_col,
     merge_meta,
+    get_keep_col,
     find_depth,
     pattern_match,
     years_match,
@@ -1329,7 +1330,7 @@ class IamDataFrame(object):
                 col_values = pd.Series(get_index_levels(self._data, col))
                 where = pattern_match(col_values, values, level, regexp)
 
-                keep_col = self._get_keep_col(col_values[where], col)
+                keep_col = get_keep_col(self._data, col_values[where], col)
 
             elif col == 'year':
                 _data = self.data[col] if self.time_col != 'time' \
@@ -1380,14 +1381,6 @@ class IamDataFrame(object):
             keep = np.logical_and(keep, keep_col)
 
         return keep
-
-    def _get_keep_col(self, values, col):
-        """Get the a list of booleans by filtering on values"""
-        keep_col = np.array([False] * len(self))
-        for v in values:
-            keep_col = np.logical_or(
-                keep_col, self._data.index.get_loc_level(v, level=col)[0])
-        return keep_col
 
     def col_apply(self, col, func, *args, **kwargs):
         """Apply a function to a column of data or meta

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1304,13 +1304,13 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        filters: dict
+        filters : dict
             dictionary of filters of the format (`{col: values}`);
             uses a pseudo-regexp syntax by default,
             but accepts `regexp: True` in the dictionary to use regexp directly
         """
         regexp = filters.pop('regexp', False)
-        keep = np.array([True] * len(self.data))
+        keep = np.array([True] * len(self))
 
         # filter by columns and list of values
         for col, values in filters.items():

--- a/pyam/index.py
+++ b/pyam/index.py
@@ -2,16 +2,12 @@ import pandas as pd
 
 
 def get_index_levels(df, level):
-    """Return the levels for a specific level"""
-    for i, n in enumerate(df.index.names):
-        if n == level:
-            return list(df.index.levels[i])
-
-    raise ValueError(f'This object does not have an index level `{level}`!')
+    """Return the category-values for a specific level"""
+    return list(df.index.levels[df.index._get_level_number(level)])
 
 
-def replace_index_values(df, level, mapping, verify_integrity=True):
-    """Replace one or several values by mapping at a particular index level"""
+def replace_index_values(df, level, mapping):
+    """Replace one or several category-values at a specific level"""
     return df.index.set_levels([mapping[i] if i in mapping else i
                                 for i in get_index_levels(df, level)], level)
 

--- a/pyam/units.py
+++ b/pyam/units.py
@@ -18,13 +18,14 @@ def convert_unit(df, current, to, factor=None, registry=None, context=None,
     try:
         where = ret._data.index.get_loc_level(current, 'unit')[0]
     except KeyError:
-        where = [False] * len(ret._data)
+        where = [False] * len(ret)
+
+    index_args = [ret._data, 'unit', {current: to}]
 
     if factor:
         # Short code path: use an explicit conversion factor, don't use pint
         ret._data[where] *= factor
-        ret._data.index = replace_index_values(ret._data, 'unit',
-                                               {current: to}, False)
+        ret._data.index = replace_index_values(*index_args)
         return None if inplace else ret
 
     # Convert using a pint.UnitRegistry; default the one from iam_units
@@ -50,8 +51,7 @@ def convert_unit(df, current, to, factor=None, registry=None, context=None,
 
     # Copy values from the result Quantity and assign units
     ret._data[where] = result.magnitude
-    ret._data.index = replace_index_values(ret._data, 'unit', {current: to},
-                                           False)
+    ret._data.index = replace_index_values(*index_args)
 
     return None if inplace else ret
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -324,6 +324,15 @@ def merge_meta(left, right, ignore_meta_conflict=False):
     return left
 
 
+def get_keep_col(data, values, col):
+    """Return a list of booleans by filtering on values"""
+    keep_col = np.array([False] * len(data))
+    for v in values:
+        keep_col = np.logical_or(
+            keep_col, data.index.get_loc_level(v, level=col)[0])
+    return keep_col
+
+
 def find_depth(data, s='', level=None):
     """Return or assert the depth (number of ``|``) of variables
 

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -328,8 +328,12 @@ def get_keep_col(data, values, col):
     """Return a list of booleans by filtering on values"""
     keep_col = np.array([False] * len(data))
     for v in values:
-        keep_col = np.logical_or(
-            keep_col, data.index.get_loc_level(v, level=col)[0])
+        slc = data.index.get_loc_level(v, level=col)[0]
+        if isinstance(slc, slice):
+            for i in range(slc.start, slc.stop, slc.step if slc.step else 1):
+                keep_col[i] = True
+        else:
+            keep_col = np.logical_or(keep_col, slc)
     return keep_col
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -12,7 +12,7 @@ def test_get_index_levels(test_df_index):
 
 def test_get_index_levels_raises(test_df_index):
     """Assert that get_index_levels raises with non-existing level"""
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         get_index_levels(test_df_index, 'foo')
 
 
@@ -30,5 +30,5 @@ def test_replace_index_level(test_pd_df, test_df_index):
 
 def test_replace_index_level_raises(test_df_index):
     """Assert that replace_index_value raises with non-existing level"""
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         replace_index_values(test_df_index, 'foo', {'scen_a': 'scen_c'})


### PR DESCRIPTION
# Description of PR

This PR refactors the `_apply_filters()` function (and some minor related changes).

Before, every value from the column was pattern-matched individually, even if it was the same (e.g., variable) string a million times. The new implementation gets the (unique) level-values directly from the index, checks which values match the pattern, and then uses the pd-internal function `get_loc_levels()` to find all occurrences of the value in the index.

In a reasonably sized test case, this increased performance by 30%.
